### PR TITLE
feat: fetch events from supabase

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,59 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabaseClient";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardDescription,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+interface Evento {
+  id: number;
+  title: string;
+  type: string;
+  duration: number;
+  description: string;
+  created_at: string;
+}
+
 export default function Home() {
-  return <h1>Bienvenido a Next.js</h1>;
+  const [eventos, setEventos] = useState<Evento[]>([]);
+
+  useEffect(() => {
+    const fetchEventos = async () => {
+      const { data } = await supabase
+        .from("cal_eventos")
+        .select("id, title, type, duration, description, created_at")
+        .order("created_at", { ascending: false });
+      if (data) {
+        setEventos(data);
+      }
+    };
+
+    fetchEventos();
+  }, []);
+
+  return (
+    <div className="p-4 space-y-4">
+      {eventos.map((evento) => (
+        <Card key={evento.id}>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle>{evento.title}</CardTitle>
+            <Badge>{evento.type}</Badge>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <CardDescription>{evento.description}</CardDescription>
+            <p className="text-sm text-muted-foreground">
+              Duración: {evento.duration} min
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Creado: {new Date(evento.created_at).toLocaleString()}
+            </p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- fetch events from `cal_eventos` table and show them using cards and badges
- configure Supabase client with provided credentials
- read Supabase configuration from `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`

## Testing
- `npm test` *(fails: Missing script)*
- `NEXT_PUBLIC_SUPABASE_URL=https://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f75ace510832bac6ab509da4250a6