### PR TITLE
feat: display events from supabase

### DIFF
--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@supabase/supabase-js"
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+const supabaseUrl = "https://etgbsbgariqydkxfjbfk.supabase.co"
+const supabaseAnonKey =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV0Z2JzYmdhcmlxeWRreGZqYmZrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM4NzI3NDEsImV4cCI6MjA2OTQ0ODc0MX0.UVNI6mgS4FG1-R99u5ebiWM-ZbFMzgI9cOQzcWJQMDQ"
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,60 @@
-export default function Home() {
-  return <h1>Bienvenido a Next.js</h1>;
+import { useEffect, useState } from "react"
+
+import { supabase } from "@/lib/supabaseClient"
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card"
+
+interface Evento {
+  id: number
+  title: string
+  type: string
+  duration: number
+  description: string
+  created_at: string
 }
+
+export default function Home() {
+  const [eventos, setEventos] = useState<Evento[]>([])
+
+  useEffect(() => {
+    const fetchEventos = async () => {
+      const { data } = await supabase
+        .from("cal_eventos")
+        .select("*")
+        .order("created_at", { ascending: false })
+
+      if (data) setEventos(data as Evento[])
+    }
+
+    fetchEventos()
+  }, [])
+
+  return (
+    <div className="p-4 space-y-4">
+      {eventos.map((evento) => (
+        <Card key={evento.id}>
+          <CardHeader className="flex items-center justify-between space-y-0">
+            <CardTitle className="text-xl font-bold">{evento.title}</CardTitle>
+            <Badge>{evento.type}</Badge>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <CardDescription>{evento.description}</CardDescription>
+            <p className="text-sm">
+              Duración: <span className="font-medium">{evento.duration}</span>
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {new Date(evento.created_at).toLocaleString()}
+            </p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- configure Supabase client with provided credentials
- fetch and render `cal_eventos` as cards on home page

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f7b386e54832b92d50d6e98fb8fd0