### PR TITLE
feat: add calendar view for reservations

### DIFF
--- a/components/CalendarView.tsx
+++ b/components/CalendarView.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import FullCalendar, { EventApi, EventClickArg } from "@fullcalendar/react"
+import dayGridPlugin from "@fullcalendar/daygrid"
+import timeGridPlugin from "@fullcalendar/timegrid"
+import interactionPlugin from "@fullcalendar/interaction"
+
+import { supabase } from "@/lib/supabaseClient"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+interface SlotType {
+  id: number
+  name: string
+  base_price: number
+}
+
+interface Reserva {
+  id: string
+  title: string
+  duration: number
+  price: number
+  start_time: string
+  slot_type_id: number
+  cal_slot_definitions: SlotType
+}
+
+interface CalendarEvent {
+  id: string
+  title: string
+  start: string
+  end: string
+  backgroundColor: string
+  borderColor: string
+  extendedProps: {
+    duration: number
+    price: number
+    typeName: string
+  }
+}
+
+const typeColors: Record<string, string> = {
+  PSY: "#60a5fa",
+  COACH: "#f472b6",
+}
+
+export default function CalendarView() {
+  const [events, setEvents] = useState<CalendarEvent[]>([])
+  const [loading, setLoading] = useState(false)
+  const [selectedEvent, setSelectedEvent] = useState<EventApi | null>(null)
+  const [open, setOpen] = useState(false)
+
+  const fetchReservations = async () => {
+    setLoading(true)
+    const { data, error } = await supabase
+      .from("cal_reservas")
+      .select(
+        "id,title,duration,price,start_time,slot_type_id, cal_slot_definitions (name,base_price)"
+      )
+
+    setLoading(false)
+    if (error || !data) {
+      console.error(error)
+      return
+    }
+
+    const mapped = data.map((reserva: Reserva): CalendarEvent => {
+      const typeName = reserva.cal_slot_definitions?.name || ""
+      const start = reserva.start_time
+      const endDate = new Date(start)
+      endDate.setMinutes(endDate.getMinutes() + reserva.duration)
+      const end = endDate.toISOString()
+
+      const color = typeColors[typeName] || "#94a3b8"
+
+      return {
+        id: reserva.id.toString(),
+        title: `${reserva.title} (${typeName})`,
+        start,
+        end,
+        backgroundColor: color,
+        borderColor: color,
+        extendedProps: {
+          duration: reserva.duration,
+          price: reserva.price,
+          typeName,
+        },
+      }
+    })
+
+    setEvents(mapped)
+  }
+
+  useEffect(() => {
+    fetchReservations()
+  }, [])
+
+  const handleEventClick = (info: EventClickArg) => {
+    setSelectedEvent(info.event)
+    setOpen(true)
+  }
+
+  const currency = new Intl.NumberFormat("es-ES", {
+    style: "currency",
+    currency: "EUR",
+  })
+
+  return (
+    <Card className="p-4 space-y-4">
+      <CardHeader className="flex items-center justify-between">
+        <CardTitle>Calendario de Reservas</CardTitle>
+        <Button onClick={fetchReservations} disabled={loading}>
+          {loading ? "Actualizando..." : "Refrescar"}
+        </Button>
+      </CardHeader>
+      <CardContent>
+        <FullCalendar
+          plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
+          initialView="timeGridWeek"
+          selectable
+          editable
+          events={events}
+          eventClick={handleEventClick}
+          headerToolbar={{
+            left: "prev,next today",
+            center: "title",
+            right: "dayGridMonth,timeGridWeek,timeGridDay",
+          }}
+        />
+      </CardContent>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{selectedEvent?.title}</DialogTitle>
+            {selectedEvent && (
+              <DialogDescription className="space-y-2">
+                <p>Tipo: {selectedEvent.extendedProps.typeName}</p>
+                <p>Duración: {selectedEvent.extendedProps.duration} min</p>
+                <p>
+                  Precio: {currency.format(selectedEvent.extendedProps.price)}
+                </p>
+                <p>
+                  Inicio: {selectedEvent.start?.toLocaleString("es-ES")}
+                </p>
+                <p>Fin: {selectedEvent.end?.toLocaleString("es-ES")}</p>
+              </DialogDescription>
+            )}
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  )
+}
+

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,94 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogOverlay = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  HTMLHeadingElement,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}
+

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,7 +1,11 @@
 import { createClient } from "@supabase/supabase-js"
 
-const supabaseUrl = "https://etgbsbgariqydkxfjbfk.supabase.co"
-const supabaseAnonKey =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV0Z2JzYmdhcmlxeWRreGZqYmZrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM4NzI3NDEsImV4cCI6MjA2OTQ0ODc0MX0.UVNI6mgS4FG1-R99u5ebiWM-ZbFMzgI9cOQzcWJQMDQ"
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error("Missing Supabase environment variables")
+}
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+

--- a/package.json
+++ b/package.json
@@ -18,7 +18,13 @@
     "@radix-ui/react-select": "^1.0.4",
     "lucide-react": "^0.379.0",
     "tailwindcss-animate": "^1.0.7",
-    "@supabase/supabase-js": "^2.39.5"
+    "@supabase/supabase-js": "^2.39.5",
+    "@fullcalendar/react": "^6.1.8",
+    "@fullcalendar/daygrid": "^6.1.8",
+    "@fullcalendar/timegrid": "^6.1.8",
+    "@fullcalendar/interaction": "^6.1.8",
+    "@fullcalendar/core": "^6.1.8",
+    "@radix-ui/react-dialog": "^1.0.5"
   },
   "devDependencies": {
     "typescript": "5.4.5",


### PR DESCRIPTION
## Summary
- add FullCalendar-based calendar view to browse Supabase reservations
- expose dialog component for event detail modals
- configure Supabase client via environment variables and add required dependencies

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Cannot find module '@fullcalendar/react' or its corresponding type declarations)


------
https://chatgpt.com/codex/tasks/task_e_688ff35d7c98832bbc0b592173ca1832