### PR TITLE
Fix FullCalendar typings in CalendarView

### DIFF
--- a/components/CalendarView.tsx
+++ b/components/CalendarView.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import FullCalendar, { EventApi, EventClickArg } from "@fullcalendar/react"
+import FullCalendar from "@fullcalendar/react"
+import { EventApi, EventClickArg } from "@fullcalendar/core"
 import dayGridPlugin from "@fullcalendar/daygrid"
 import timeGridPlugin from "@fullcalendar/timegrid"
 import interactionPlugin from "@fullcalendar/interaction"
@@ -108,8 +109,9 @@ export default function CalendarView() {
     fetchReservations()
   }, [])
 
-  const handleEventClick = (info: EventClickArg) => {
-    setSelectedEvent(info.event)
+  const handleEventClick = (arg: EventClickArg) => {
+    const event: EventApi = arg.event
+    setSelectedEvent(event)
     setOpen(true)
   }
 


### PR DESCRIPTION
## Summary
- fix FullCalendar imports for v6
- type event click handler with EventApi and EventClickArg from @fullcalendar/core

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Argument type mismatch in CalendarView.tsx:81)*

------
https://chatgpt.com/codex/tasks/task_e_688ff99487b4832b85be675f8c472e00