### PR TITLE
fix: allow null slot definitions in calendar view

### DIFF
--- a/components/CalendarView.tsx
+++ b/components/CalendarView.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import FullCalendar, { EventApi, EventClickArg } from "@fullcalendar/react"
+import FullCalendar from "@fullcalendar/react"
+import type { EventApi, EventClickArg } from "@fullcalendar/core"
 import dayGridPlugin from "@fullcalendar/daygrid"
 import timeGridPlugin from "@fullcalendar/timegrid"
 import interactionPlugin from "@fullcalendar/interaction"
@@ -35,7 +36,7 @@ interface Reserva {
   price: number
   start_time: string
   slot_type_id: number
-  cal_slot_definitions: SlotType
+  cal_slot_definitions?: SlotType | null
 }
 
 interface CalendarEvent {
@@ -77,7 +78,7 @@ export default function CalendarView() {
       return
     }
 
-    const mapped = data.map((reserva: Reserva): CalendarEvent => {
+    const mapped = (data as unknown as Reserva[]).map((reserva): CalendarEvent => {
       const typeName = reserva.cal_slot_definitions?.name || ""
       const start = reserva.start_time
       const endDate = new Date(start)


### PR DESCRIPTION
## Summary
- make `cal_slot_definitions` optional in reservation interface
- update FullCalendar imports and cast fetched data for type safety

## Testing
- `npm run build` *(fails: Invalid URL YOUR_SUPABASE_URL/)*

------
https://chatgpt.com/codex/tasks/task_e_688ffdf26e84832b82e658c03462eaa6