### PR TITLE
feat: add calendar link card to home

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useState } from "react"
+import Link from "next/link"
 
-import { supabase } from "@/lib/supabaseClient"
-import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -10,50 +9,22 @@ import {
   CardDescription,
 } from "@/components/ui/card"
 
-interface Evento {
-  id: number
-  title: string
-  type: string
-  duration: number
-  description: string
-  created_at: string
-}
-
 export default function Home() {
-  const [eventos, setEventos] = useState<Evento[]>([])
-
-  useEffect(() => {
-    const fetchEventos = async () => {
-      const { data } = await supabase
-        .from("cal_eventos")
-        .select("*")
-        .order("created_at", { ascending: false })
-
-      if (data) setEventos(data as Evento[])
-    }
-
-    fetchEventos()
-  }, [])
-
   return (
-    <div className="p-4 space-y-4">
-      {eventos.map((evento) => (
-        <Card key={evento.id}>
-          <CardHeader className="flex items-center justify-between space-y-0">
-            <CardTitle className="text-xl font-bold">{evento.title}</CardTitle>
-            <Badge>{evento.type}</Badge>
-          </CardHeader>
-          <CardContent className="space-y-2">
-            <CardDescription>{evento.description}</CardDescription>
-            <p className="text-sm">
-              Duración: <span className="font-medium">{evento.duration}</span>
-            </p>
-            <p className="text-xs text-muted-foreground">
-              {new Date(evento.created_at).toLocaleString()}
-            </p>
-          </CardContent>
-        </Card>
-      ))}
+    <div className="p-6">
+      <Card className="mx-auto max-w-3xl space-y-4 p-6">
+        <CardHeader>
+          <CardTitle>Calendario</CardTitle>
+          <CardDescription>
+            Administra y reserva tus slots desde el calendario
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button asChild size="lg">
+            <Link href="/calendar">Ver calendario</Link>
+          </Button>
+        </CardContent>
+      </Card>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- replace home page with card linking to calendar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689002b8a100832ba580dc224150a51a