### PR TITLE
feat: add calendar calendar page with FullCalendar dynamic import

### DIFF
--- a/components/CalendarView.tsx
+++ b/components/CalendarView.tsx
@@ -1,7 +1,7 @@
-"use client"
+"use client";
 
 import { useEffect, useState } from "react"
-import FullCalendar from "@fullcalendar/react"
+import dynamic from "next/dynamic"
 import type { EventApi, EventClickArg } from "@fullcalendar/core"
 import dayGridPlugin from "@fullcalendar/daygrid"
 import timeGridPlugin from "@fullcalendar/timegrid"
@@ -22,6 +22,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+
+const FullCalendar = dynamic(() => import("@fullcalendar/react"), { ssr: false })
 
 interface SlotType {
   id: number

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -1,0 +1,14 @@
+import dynamic from "next/dynamic"
+
+const CalendarView = dynamic(() => import("@/components/CalendarView"), {
+  ssr: false,
+})
+
+export default function CalendarPage() {
+  return (
+    <div className="container mx-auto p-4 flex justify-center">
+      <CalendarView />
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add dynamic FullCalendar import and client directive to CalendarView
- add calendar page using CalendarView in centered container

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890061305ac832baa258ea867647d48